### PR TITLE
Add support for Python 3.6 and Fix #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,3 @@ htmlcov
 
 doc/_build
 doc/__pycache__
-doc/changelog.rst

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ python:
   - 2.7
   - 3.4
   - 3.5
-  - pypy
+  - 3.6
+  - pypy-5.4.1
 script:
-  - coverage run `which zope-testrunner` --test-path=src  --auto-color --auto-progress
+  - coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
 after_success:
   - coveralls
 notifications:
@@ -17,13 +18,8 @@ install:
   - pip install -U coveralls coverage
   - pip install -U -e ".[test]"
 
-# cache: pip seems not to work if `install` is replaced (https://github.com/travis-ci/travis-ci/issues/3239)
-cache:
-  directories:
-    - $HOME/.cache/pip
-    - $HOME/.venv
-    - $HOME/.runtimes
-    - $HOME/.wheelhouse
+
+cache: pip
 
 before_cache:
     - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,10 +5,12 @@
 =========
 
 
-1.1.4 (unreleased)
+1.2.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Remove use of ``unicode_literals``.
+
+- Add support for Python 3.6.
 
 
 1.1.3 (2017-01-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@
 
 - Add support for Python 3.6.
 
+- The ``SchemaConfigured`` constructor doesn't hide errors when
+  checking for properties on Python 2. See `issue 11
+  <https://github.com/NextThought/nti.schema/issues/11>`_.
+
 
 1.1.3 (2017-01-17)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ schema-based development with zope.schema easier.
 For complete details and the changelog, see the `documentation <http://ntischema.readthedocs.io/>`_.
 
 Overview
---------
+========
 
 Some of the most useful features include:
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,0 +1,1 @@
+.. include:: ../CHANGES.rst

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,16 +31,7 @@
 # ones.
 
 from __future__ import print_function
-import os
 
-
-if not os.path.exists('changelog.rst') and os.path.exists('../CHANGES.rst'):
-    print('Linking ../CHANGES.rst to changelog.rst')
-    if hasattr(os, 'symlink'):
-        os.symlink('../CHANGES.rst', 'changelog.rst')
-    else:
-        import shutil
-        shutil.copyfile('../CHANGES.rst', 'changelog.rst')
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/setup.py
+++ b/setup.py
@@ -7,21 +7,23 @@ version = '1.1.4.dev0'
 entry_points = {
 }
 
+
 def _read(fname):
     with codecs.open(fname, encoding='utf-8') as f:
         return f.read()
 
+
 setup(
-    name = 'nti.schema',
-    version = version,
-    author = 'Jason Madden',
-    author_email = 'open-source@nextthought.com',
-    description = ('Zope schema related support'),
-    long_description = _read('README.rst'),
-    license = 'Apache',
-    keywords = 'zope schema',
-    url = 'https://github.com/NextThought/nti.schema',
-    classifiers = [
+    name='nti.schema',
+    version=version,
+    author='Jason Madden',
+    author_email='open-source@nextthought.com',
+    description=('Zope schema related support'),
+    long_description=_read('README.rst'),
+    license='Apache',
+    keywords='zope schema',
+    url='https://github.com/NextThought/nti.schema',
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
@@ -32,6 +34,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Framework :: Zope3',
@@ -52,8 +55,7 @@ setup(
         'zope.deferredimport',
     ],
     extras_require={
-        'test':[
-            'nose2',
+        'test': [
             'pyhamcrest',
             'nti.testing',
             'zope.testrunner',
@@ -62,10 +64,9 @@ setup(
             # Not ported to Py3 yet; Plus, version 3 adds hard dep on
             # Products.CMFCore/Zope2 that we don't want.
             'plone.i18n < 3.0',
-            'zope.browserresource', # Used by plone.i18n implicitly
+            'zope.browserresource',  # Used by plone.i18n implicitly
         ]
     },
     namespace_packages=['nti'],
     entry_points=entry_points,
-    test_suite='nose2.compat.unittest.collector'
 )

--- a/src/nti/__init__.py
+++ b/src/nti/__init__.py
@@ -1,2 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
-
+__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover

--- a/src/nti/schema/field.py
+++ b/src/nti/schema/field.py
@@ -10,7 +10,7 @@ to be imported from this module.
 .. TODO: This module is big enough it should be factored into a package and sub-modules.
 """
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function,  absolute_import, division
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
@@ -135,18 +135,18 @@ class FieldValidationMixin(object):
     def _reraise_validation_error(self, e, value, _raise=False):
         if len(e.args) == 1:  # typically the message is the only thing
             self._fixup_validation_error_args(e, value)
-        elif len(e.args) == 0:  # Typically a SchemaNotProvided. Grr.
+        elif not e.args:  # Typically a SchemaNotProvided. Grr.
             self._fixup_validation_error_no_args(e, value)
         elif isinstance(e, sch_interfaces.TooShort) and len(e.args) == 2:
             # Note we're capitalizing the field in the message.
-            e.i18n_message = _('${field} is too short. Please use at least ${minLength} characters.',
+            e.i18n_message = _(u'${field} is too short. Please use at least ${minLength} characters.',
                                 mapping={'field': self.__fixup_name__.capitalize(),
                                         'minLength': e.args[1]})
             e.args = (self.__fixup_name__.capitalize() + ' is too short.',
                        self.__fixup_name__,
                        value)
         elif isinstance(e, sch_interfaces.TooLong) and len(e.args) == 2:
-            e.i18n_message = _('${field} is too long. ${max_size} character limit.',
+            e.i18n_message = _(u'${field} is too long. ${max_size} character limit.',
                                 mapping={'field': self.__fixup_name__.capitalize(),
                                         'max_size': e.args[1]})
             e.args = (self.__fixup_name__.capitalize() + ' is too long.',
@@ -470,11 +470,11 @@ class HTTPURL(ValidURI):
         orig_value = value
         if value:
             lower = value.lower()
-            if not lower.startswith('http://') and not lower.startswith('https://'):
+            if not lower.startswith(u'http://') and not lower.startswith(u'https://'):
                 # assume http
-                value = 'http://' + value
+                value = u'http://' + value
         result = super(HTTPURL, self).fromUnicode(value)
-        if result.count(':') != 1:
+        if result.count(u':') != 1:
             self._reraise_validation_error(sch_interfaces.InvalidURI(orig_value), orig_value, _raise=True)
 
         return result

--- a/src/nti/schema/fieldproperty.py
+++ b/src/nti/schema/fieldproperty.py
@@ -3,10 +3,9 @@
 """
 Computed attributes based on schema fields.
 
-.. $Id$
 """
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)

--- a/src/nti/schema/interfaces.py
+++ b/src/nti/schema/interfaces.py
@@ -6,7 +6,7 @@ Interfaces describing the events and fields this package uses.
 Also utility functions.
 """
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
@@ -24,11 +24,11 @@ class IBeforeSchemaFieldAssignedEvent(interface.Interface):
     The interface :class:`.IBeforeObjectAssignedEvent` is a sub-interface
     of this one.
     """
-    object = interface.Attribute("The object that is going to be assigned. Subscribers may modify this")
+    object = interface.Attribute(u"The object that is going to be assigned. Subscribers may modify this")
 
-    name = interface.Attribute("The name of the attribute under which the object will be assigned.")
+    name = interface.Attribute(u"The name of the attribute under which the object will be assigned.")
 
-    context = interface.Attribute("The context object where the object will be assigned to.")
+    context = interface.Attribute(u"The context object where the object will be assigned to.")
 
 # Make this a base of the zope interface so our handlers
 # are compatible
@@ -47,14 +47,14 @@ class IBeforeTextAssignedEvent(IBeforeSchemaFieldAssignedEvent):
     Event for assigning text.
     """
 
-    object = schema.Text(title="The text being assigned.")
+    object = schema.Text(title=u"The text being assigned.")
 
 class IBeforeTextLineAssignedEvent(IBeforeTextAssignedEvent):  # ITextLine extends IText
     """
     Event for assigning text lines.
     """
 
-    object = schema.TextLine(title="The text being assigned.")
+    object = schema.TextLine(title=u"The text being assigned.")
 
 class IBeforeContainerAssignedEvent(IBeforeSchemaFieldAssignedEvent):
     """
@@ -71,7 +71,7 @@ class IBeforeCollectionAssignedEvent(IBeforeIterableAssignedEvent):
     Event for assigning collections.
     """
 
-    object = interface.Attribute("The collection being assigned. May or may not be mutable.")
+    object = interface.Attribute(u"The collection being assigned. May or may not be mutable.")
 
 class IBeforeSetAssignedEvent(IBeforeCollectionAssignedEvent):
     """
@@ -83,7 +83,7 @@ class IBeforeSequenceAssignedEvent(IBeforeCollectionAssignedEvent):
     Event for assigning sequences.
     """
 
-    object = interface.Attribute("The sequence being assigned. May or may not be mutable.")
+    object = interface.Attribute(u"The sequence being assigned. May or may not be mutable.")
 
 class IBeforeDictAssignedEvent(IBeforeIterableAssignedEvent):
     """

--- a/src/nti/schema/jsonschema.py
+++ b/src/nti/schema/jsonschema.py
@@ -8,7 +8,7 @@ For producing a JSON schema appropriate for use by clients, based on a Zope sche
 .. $Id$
 """
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
@@ -114,9 +114,11 @@ def get_data_from_choice_field(v, base_type=None):
                     # like nti.externalization, but without the dependency
                     choice = term.toExternalObject()
                 except AttributeError: # pragma: no cover
-                    choice = {'token': term.token,
-                              'value': term.value,
-                              'title': term.title}
+                    choice = {
+                        'token': term.token,
+                        'value': term.value,
+                        'title': term.title
+                    }
 
                 choices.append(choice)
             else: # pragma: no cover
@@ -208,11 +210,13 @@ class JsonSchemafier(object):
                 readonly = v.queryTaggedValue(TAG_READONLY_IN_UI) or readonly
 
             ui_base_type = None
-            item_schema = {'name': k,
-                           'required': required,
-                           'readonly': readonly,
-                           'min_length': getattr(v, 'min_length', None),
-                           'max_length': getattr(v, 'max_length', None) }
+            item_schema = {
+                'name': k,
+                'required': required,
+                'readonly': readonly,
+                'min_length': getattr(v, 'min_length', None),
+                'max_length': getattr(v, 'max_length', None)
+            }
             ui_type = v.queryTaggedValue(TAG_UI_TYPE)
             if not ui_type:
                 ui_type, ui_base_type = self.get_ui_types_from_field(v)

--- a/src/nti/schema/schema.py
+++ b/src/nti/schema/schema.py
@@ -6,7 +6,7 @@ Helpers for writing code that implements schemas.
 This module contains code based on code originally from dm.zope.schema.
 """
 
-from __future__ import print_function, absolute_import, division
+from __future__ import absolute_import, print_function, division
 __docformat__ = "restructuredtext en"
 
 from zope import interface

--- a/src/nti/schema/schema.py
+++ b/src/nti/schema/schema.py
@@ -57,8 +57,14 @@ def schemadict(spec):
 
 if hasattr(dict, 'iteritems'):
     _iteritems = dict.iteritems
+    _marker = object()
+    # The point of this is to avoid hiding exceptions (which the builtin
+    # hasattr() does on Python 2)
+    def _hasattr(o, name):
+        return getattr(o, name, _marker) is not _marker
 else:
     _iteritems = dict.items
+    _hasattr = hasattr
 
 
 @interface.implementer(ISchemaConfigured)
@@ -74,7 +80,7 @@ class SchemaConfigured(object):
             setattr(self, k, v)
         # provide default values for schema fields not set
         for f, fields in _iteritems(schema):
-          if not hasattr(self, f):
+          if not _hasattr(self, f):
               setattr(self, f, fields.default)
 
     # provide control over which interfaces define the data schema

--- a/src/nti/schema/subscribers.py
+++ b/src/nti/schema/subscribers.py
@@ -3,10 +3,9 @@
 """
 Event handlers.
 
-.. $Id$
 """
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
@@ -27,4 +26,4 @@ def before_object_assigned_event_dispatcher(event):
 
     This is analogous to :func:`zope.component.event.objectEventNotify`
     """
-    handle( event.object, event.context, event )
+    handle(event.object, event.context, event)

--- a/src/nti/schema/testing.py
+++ b/src/nti/schema/testing.py
@@ -3,10 +3,9 @@
 """
 Test support for schemas and interfaces, mostly in the form of Hamcrest matchers.
 
-.. $Id$
 """
 
-from __future__ import print_function, absolute_import, division
+from __future__ import print_function, division
 
 from zope.deferredimport import deprecatedFrom
 

--- a/src/nti/schema/tests/test_eqhash.py
+++ b/src/nti/schema/tests/test_eqhash.py
@@ -3,7 +3,6 @@
 """
 
 
-.. $Id$
 """
 
 from __future__ import print_function, absolute_import, division

--- a/src/nti/schema/tests/test_field.py
+++ b/src/nti/schema/tests/test_field.py
@@ -2,11 +2,9 @@
 # -*- coding: utf-8 -*-
 """
 
-
-.. $Id$
 """
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
@@ -76,19 +74,19 @@ class TestObjectLen(unittest.TestCase):
 
         olen = ObjectLen(IUnicode, max_length=5)  # default val for min_length
 
-        olen.validate('a')
-        olen.validate('')
+        olen.validate(u'a')
+        olen.validate(u'')
 
         assert_that(calling(olen.validate).with_args(object()),
                      raises(SchemaNotProvided))
 
-        assert_that(calling(olen.validate).with_args('abcdef'),
+        assert_that(calling(olen.validate).with_args(u'abcdef'),
                      raises(TooLong))
 
     def test_objectlen_short(self):
         olen = ObjectLen(IUnicode, min_length=5)
 
-        assert_that(calling(olen.validate).with_args('abc'),
+        assert_that(calling(olen.validate).with_args(u'abc'),
                      raises(TooShort))
 
 class TestHTTPUrl(unittest.TestCase):
@@ -130,7 +128,7 @@ class TestVariant(unittest.TestCase):
         # doesn't validate
         assert_that(b'foo', not_validated_by(syntax_or_lookup))
 
-        assert_that(syntax_or_lookup.fromObject('foo'), is_('foo'))
+        assert_that(syntax_or_lookup.fromObject(u'foo'), is_(u'foo'))
 
         assert_that(calling(syntax_or_lookup.fromObject).with_args(object()),
                      raises(TypeError))
@@ -147,11 +145,11 @@ class TestVariant(unittest.TestCase):
         variant = Variant((dict_field, string_field, list_of_numbers_field))
         variant.getDoc()  # cover
         # It takes all these things
-        for d in { 'k': 'v'}, 'foo', [1, 2, 3]:
+        for d in {u'k': u'v'}, u'foo', [1, 2, 3]:
             assert_that(d, validated_by(variant))
 
         # It rejects these
-        for d in {'k': 1}, b'foo', [1, 2, 'b']:
+        for d in {u'k': 1}, b'foo', [1, 2, u'b']:
             assert_that(d, not_validated_by(variant))
 
         # A name set now is reflected down the line
@@ -199,7 +197,7 @@ class TestVariant(unittest.TestCase):
         assert_that(field.fromObject("1.0"),
                     is_(1.0))
 
-        assert_that(calling(field.validate).with_args('1.0'),
+        assert_that(calling(field.validate).with_args(u'1.0'),
                     raises(SchemaNotProvided))
 
     def test_invalid_construct(self):
@@ -220,19 +218,19 @@ class TestConfiguredVariant(unittest.TestCase):
         number_field = Number()
         list_of_strings_or_numbers = ListOrTuple(value_type=Variant((string_field, number_field)))
 
-        assert_that([1, '2'], validated_by(list_of_strings_or_numbers))
-        assert_that({'k': 'v'}, validated_by(dict_field))
+        assert_that([1, u'2'], validated_by(list_of_strings_or_numbers))
+        assert_that({u'k': u'v'}, validated_by(dict_field))
 
         dict_or_list = Variant((dict_field, list_of_strings_or_numbers))
 
-        assert_that([1, '2'], validated_by(dict_or_list))
-        assert_that({'k': 'v'}, validated_by(dict_or_list))
+        assert_that([1, u'2'], validated_by(dict_or_list))
+        assert_that({u'k': u'v'}, validated_by(dict_or_list))
 
         class X(object):
             pass
 
         x = X()
-        dict_or_list.set(x, [1, '2'])
+        dict_or_list.set(x, [1, u'2'])
 
         events = eventtesting.getEvents(IBeforeSequenceAssignedEvent)
         assert_that(events, has_length(1))
@@ -240,7 +238,7 @@ class TestConfiguredVariant(unittest.TestCase):
 
         eventtesting.clearEvents()
 
-        dict_or_list.set(x, {'k': 'v'})
+        dict_or_list.set(x, {u'k': u'v'})
         events = eventtesting.getEvents(IBeforeDictAssignedEvent)
         assert_that(events, has_length(1))
         assert_that(events, contains(has_property('object', {'k': 'v'})))

--- a/src/nti/schema/tests/test_fieldproperty.py
+++ b/src/nti/schema/tests/test_fieldproperty.py
@@ -2,11 +2,9 @@
 # -*- coding: utf-8 -*-
 """
 
-
-.. $Id$
 """
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
@@ -87,7 +85,7 @@ class TestCreateFieldProperties(unittest.TestCase):
             pass
 
         class IA(interface.Interface):
-            a = TextLine(title="a")
+            a = TextLine(title=u"a")
 
         class IB(IA):
             b = Object(IBaz)
@@ -111,7 +109,7 @@ class TestUnicodeFieldProperty(unittest.TestCase):
 
     def test_set_bytes(self):
         class IA(interface.Interface):
-            a = TextLine(title="a")
+            a = TextLine(title=u"a")
 
         class A(object):
             a = UnicodeConvertingFieldProperty(IA['a'])

--- a/src/nti/schema/tests/test_interfaces.py
+++ b/src/nti/schema/tests/test_interfaces.py
@@ -3,10 +3,9 @@
 """
 
 
-.. $Id$
 """
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)

--- a/src/nti/schema/tests/test_jsonschema.py
+++ b/src/nti/schema/tests/test_jsonschema.py
@@ -2,11 +2,9 @@
 # -*- coding: utf-8 -*-
 """
 
-
-.. $Id$
 """
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)

--- a/src/nti/schema/tests/test_schema.py
+++ b/src/nti/schema/tests/test_schema.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
@@ -22,18 +22,21 @@ does_not = is_not
 import unittest
 
 from zope import interface
+from zope.component import eventtesting
+
+from . import SchemaLayer
 from . import IUnicode
 
-from nti.schema.field import Number
-from nti.schema.field import Object
-
-
-from nti.schema.field import DictFromObject
-from nti.schema.field import ValidTextLine as TextLine
+from ..field import Number
+from ..field import Object
+from ..field import DictFromObject
+from ..field import ValidTextLine as TextLine
 
 from ..schema import PermissiveSchemaConfigured
+from ..schema import SchemaConfigured
 
-from nti.schema.interfaces import IBeforeDictAssignedEvent
+
+from ..interfaces import IBeforeDictAssignedEvent
 
 
 class TestMisc(unittest.TestCase):
@@ -74,9 +77,21 @@ class TestSchemaConfigured(unittest.TestCase):
         a = A(field=1)
         assert_that(a, has_property('field', 1))
 
+    def test_readonly(self):
+        # https://github.com/NextThought/nti.schema/issues/11
+        from nti.schema.fieldproperty import createDirectFieldProperties
+        class IA(interface.Interface):
+            field = Number(readonly=True,
+                           required=False,
+                           default=1)
 
-from . import SchemaLayer
-from zope.component import eventtesting
+        @interface.implementer(IA)
+        class A(SchemaConfigured):
+            createDirectFieldProperties(IA)
+
+        a = A()
+        assert_that(a, has_property('field', 1))
+
 
 class TestConfigured(unittest.TestCase):
 
@@ -92,9 +107,9 @@ class TestConfigured(unittest.TestCase):
             pass
 
         x = X()
-        dict_field.set(x, dict_field.fromObject({'k': '1'}))
+        dict_field.set(x, dict_field.fromObject({u'k': u'1'}))
 
-        assert_that(x, has_property('dict', {'k': 1.0}))
+        assert_that(x, has_property('dict', {u'k': 1.0}))
 
         events = eventtesting.getEvents(IBeforeDictAssignedEvent)
         assert_that(events, has_length(1))

--- a/src/nti/schema/tests/test_schema.py
+++ b/src/nti/schema/tests/test_schema.py
@@ -78,7 +78,6 @@ class TestSchemaConfigured(unittest.TestCase):
         assert_that(a, has_property('field', 1))
 
     def test_readonly(self):
-        # https://github.com/NextThought/nti.schema/issues/11
         from nti.schema.fieldproperty import createDirectFieldProperties
         class IA(interface.Interface):
             field = Number(readonly=True,
@@ -91,6 +90,23 @@ class TestSchemaConfigured(unittest.TestCase):
 
         a = A()
         assert_that(a, has_property('field', 1))
+
+    def test_property_raises_exception(self):
+        # https://github.com/NextThought/nti.schema/issues/11
+        class IA(interface.Interface):
+            field = Number(readonly=True,
+                           required=False,
+                           default=1)
+
+        @interface.implementer(IA)
+        class A(SchemaConfigured):
+            @property
+            def field(self):
+                raise ValueError("bad field")
+
+        # We can still create it without raising an AttributeError;
+        # in fact, the ValueError is propagated
+        assert_that(calling(A), raises(ValueError, "bad field"))
 
 
 class TestConfigured(unittest.TestCase):

--- a/src/nti/schema/tests/test_vocabulary.py
+++ b/src/nti/schema/tests/test_vocabulary.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function, unicode_literals, absolute_import, division
-__docformat__ = "restructuredtext en"
-
-logger = __import__('logging').getLogger(__name__)
+from __future__ import print_function, absolute_import, division
 
 # disable: accessing protected members, too many methods
 # pylint: disable=W0212,R0904
@@ -36,8 +33,8 @@ class TestConfiguredVocabulary(unittest.TestCase):
         from zope.schema import Choice
 
         class IA(interface.Interface):
-            choice = Choice(title="Choice",
-                            vocabulary="Countries")
+            choice = Choice(title=u"Choice",
+                            vocabulary=u"Countries")
 
         o = object()
 

--- a/src/nti/schema/vocabulary.py
+++ b/src/nti/schema/vocabulary.py
@@ -12,13 +12,9 @@ vocabulary named ``Countries`` available::
   class IA(interface.Interface):
     choice = Choice(title="Choice",
                      vocabulary="Countries")
-
-
-
-.. $Id$
 """
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
@@ -36,6 +32,8 @@ except ImportError:
     class _ICountryAvailability(interface.Interface):
         def getCountries():
             ""
+
+
 @interface.implementer(_ICountryAvailability)
 class _CountryAvailabilityFallback(object):
 
@@ -67,10 +65,12 @@ class CountryTerm(_SimpleTerm):
         return cls(value, token, title, flag=flag)
 
     def toExternalObject(self):
-        return { 'token': self.token,
-                 'title': self.title,
-                 'value': self.value,
-                 'flag': self.flag }
+        return {
+            'token': self.token,
+            'title': self.title,
+            'value': self.value,
+            'flag': self.flag
+        }
 
 class _CountryVocabulary(_SimpleVocabulary):
     """

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = pypy, py27, py34, py35
+envlist = pypy, py27, py34, py35, py36
 
 [testenv]
 deps =
-     nti.testing
-     zope.testrunner
+     .[test]
 
 
 setenv =


### PR DESCRIPTION
Also remove use of ``unicode_literals`` throughout the code base.