### PR TITLE
Updates for zope.schema 4.6.0

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ omit = src/nti/schema/tests/*benchmark.py
 # Coverage is run on Linux under cPython 2 and 3,
 # exclude branches that are windows, pypy
 # specific
+precision = 2
 exclude_lines =
     pragma: no cover
     def __repr__

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,11 +3,16 @@
 =========
 
 
-1.3.4 (unreleased)
+1.4.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Drop support for ``dm.zope.schema`` fields, in particular the
+  ``Object`` field. The validation performed by ``zope.schema.Object``
+  is much improved.
 
+- Drop support for ``zope.schema`` older than 4.6.0.
+
+- Deprecate ``nti.schema.field.Number``.
 
 1.3.3 (2018-09-07)
 ==================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -364,5 +364,4 @@ extlinks = {'issue': ('https://github.com/NextThought/nti.schema/issues/%s',
                    'pull request #')}
 
 autodoc_default_flags = ['members', 'show-inheritance']
-autoclass_content = 'both'
 autodoc_member_order = 'bysource'

--- a/docs/field.rst
+++ b/docs/field.rst
@@ -4,4 +4,3 @@
 
 .. automodule:: nti.schema.field
     :members:
-    :undoc-members:

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'zope.i18n',
         'zope.i18nmessageid',
         'zope.vocabularyregistry',
+        'zope.deprecation',
         'zope.deferredimport >= 4.2.1',
     ],
     extras_require={
@@ -66,6 +67,7 @@ setup(
         ],
         'docs': [
             'Sphinx',
+            'nti.testing',
             'repoze.sphinx.autointerface',
             'sphinx_rtd_theme',
         ],

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'six',
         'setuptools',
         'zope.event',
-        'zope.schema >= 4.6.0',
+        'zope.schema >= 4.6.1',
         'zope.i18n',
         'zope.i18nmessageid',
         'zope.vocabularyregistry',

--- a/src/nti/schema/eqhash.py
+++ b/src/nti/schema/eqhash.py
@@ -51,6 +51,8 @@ def _superhash(value):
 def EqHash(*names,
            **kwargs):
     """
+    EqHash(*names, include_super=False, superhash=False, include_type=False)
+
     A class decorator factory for the common pattern of writing
     ``__eq__``/``__ne__`` and ``__hash__`` methods that check the same
     list of attributes on a given object.

--- a/src/nti/schema/field.py
+++ b/src/nti/schema/field.py
@@ -55,7 +55,6 @@ from nti.schema.interfaces import BeforeTextAssignedEvent
 from nti.schema.interfaces import BeforeTextLineAssignedEvent
 from nti.schema.interfaces import IFromObject
 from nti.schema.interfaces import IListOrTuple
-from nti.schema.interfaces import InvalidValue
 from nti.schema.interfaces import IVariant
 
 from .schema import SchemaConfigured
@@ -109,7 +108,6 @@ def __with_set(eventfactory=BeforeSchemaFieldAssignedEvent):
         return cls
     return X
 
-InvalidValue = InvalidValue
 
 class FieldValidationMixin(object):
     """

--- a/src/nti/schema/fieldproperty.py
+++ b/src/nti/schema/fieldproperty.py
@@ -24,7 +24,7 @@ __docformat__ = "restructuredtext en"
 class AcquisitionFieldProperty(FieldProperty):
     """
     A field property that supports acquisition. Returned objects
-    will be __of__ the instance, and set objects will always be the unwrapped
+    will be ``__of__`` the instance, and set objects will always be the unwrapped
     base.
     """
 

--- a/src/nti/schema/interfaces.py
+++ b/src/nti/schema/interfaces.py
@@ -10,6 +10,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from zope.deprecation import deprecated
+
 from zope.schema import Text
 from zope.schema import TextLine
 from zope.interface import Interface
@@ -133,26 +135,34 @@ class BeforeDictAssignedEvent(BeforeSchemaFieldAssignedEvent):
 
 BeforeObjectAssignedEvent = BeforeObjectAssignedEvent
 
-class InvalidValue(sch_interfaces.InvalidValue):
+def InvalidValue(*args, **kwargs):
     """
+    InvalidValue(*args, field=None, value=None)
+
     Adds a field specifically to carry the value that is invalid.
+
+    .. deprecated:: 1.4.0
+       This is now just a convenience wrapper around
+       :class:`zope.schema.interfaces.InvalidValue` that calls
+       :meth:`.zope.schema.interfaces.ValidationError.with_field_and_value`
+       before returning the exception.
     """
-    value = None
+    # We can't write the syntax we want to in Python 2.
 
-    def __init__(self, *args, **kwargs):
-        super(InvalidValue, self).__init__(*args)
-        if 'value' in kwargs:
-            self.value = kwargs['value']
-        if 'field' in kwargs:
-            self.field = kwargs['field']
+    field = kwargs.pop('field', None)
+    value = kwargs.pop('value', None)
+    if kwargs:
+        raise TypeError("Too many kwargs for function InvalidValue")
+    return sch_interfaces.InvalidValue(*args).with_field_and_value(
+        field, value
+    )
 
-# And we monkey patch it in to InvalidValue as well
-if not hasattr(sch_interfaces.InvalidValue, 'value'):
-    setattr(sch_interfaces.InvalidValue, 'value', None)
+deprecated('InvalidValue',
+           "Use zope.schema.interfaces.InvalidValue.with_field_and_value.")
 
-# And give all validation errors a 'field'
-if not hasattr(sch_interfaces.ValidationError, 'field'):
-    setattr(sch_interfaces.ValidationError, 'field', None)
+assert hasattr(sch_interfaces.InvalidValue, 'value')
+assert hasattr(sch_interfaces.ValidationError, 'field')
+
 
 class IFromObject(Interface):
     """

--- a/src/nti/schema/testing.py
+++ b/src/nti/schema/testing.py
@@ -17,10 +17,5 @@ moved to :mod:`nti.testing.matchers`:
 from __future__ import division
 from __future__ import print_function
 
-from zope.deferredimport import deprecatedFrom
-
-deprecatedFrom("Matchers live in nti.testing.matchers",
-               "nti.testing.matchers",
-               "provides", "implements",
-               "verifiably_provides", "validly_provides",
-               "validated_by", "not_validated_by")
+from zope.deprecation import moved
+moved('nti.testing.matchers')

--- a/src/nti/schema/tests/test_eqhash.py
+++ b/src/nti/schema/tests/test_eqhash.py
@@ -185,7 +185,10 @@ class TestSuperHash(unittest.TestCase):
     def superhash(self, arg):
         # Use the old location to make sure it works
         from nti.schema import schema
-        return schema._superhash(arg) # pylint:disable=no-member
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            return schema._superhash(arg) # pylint:disable=no-member
 
     def test_iterable(self):
         assert_that(hash(self.superhash([1, 3, 5])),

--- a/src/nti/schema/tests/test_interfaces.py
+++ b/src/nti/schema/tests/test_interfaces.py
@@ -12,7 +12,10 @@ from __future__ import print_function
 # stdlib imports
 import unittest
 
-from ..interfaces import InvalidValue
+from zope.deprecation import Suppressor
+
+with Suppressor():
+    from ..interfaces import InvalidValue
 
 from hamcrest import assert_that
 from hamcrest import has_property
@@ -33,3 +36,6 @@ class TestInvalidValue(unittest.TestCase):
         v = InvalidValue(value=1, field=1)
         assert_that(v, has_property('value', 1))
         assert_that(v, has_property('field', 1))
+
+        with self.assertRaises(TypeError):
+            InvalidValue(value=1, field=2, other=3)


### PR DESCRIPTION
Drop support for dm.zope.schema.Object, and older versions of zope.schema, altogether.

Fixes #21