### PR TITLE
Make InvalidValue just an alias for the zope.schema version.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@
 1.5.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Adjust the deprecated ``zope.schema.interfaces.InvalidValue`` to be
+  a simple alias for ``zope.schema.interfaces.InvalidValue`` (while
+  preserving the constructor) for improved backwards compatibility.
 
 
 1.5.0 (2018-09-11)

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -5,3 +5,14 @@
 .. automodule:: nti.schema.interfaces
     :members:
     :undoc-members:
+
+.. exception:: InvalidValue(*args, field=None, value=None)
+
+    Adds a field specifically to carry the value that is invalid.
+
+    .. deprecated:: 1.4.0
+        This is now just a convenience wrapper around
+        :class:`zope.schema.interfaces.InvalidValue` that calls
+        :meth:`.zope.schema.interfaces.ValidationError.with_field_and_value`
+        before returning the exception. You should always catch
+        :class:`zope.schema.interfaces.InvalidValue`.

--- a/src/nti/schema/tests/test_interfaces.py
+++ b/src/nti/schema/tests/test_interfaces.py
@@ -43,13 +43,29 @@ class TestInvalidValue(unittest.TestCase):
             InvalidValue(value=1, field=2, other=3)
 
     def test_subclass(self):
-        type('subclass', (InvalidValue,), {})
+        kind = type('subclass', (InvalidValue,), {})
+        self.test_instance(kind)
+        self.test_raise_except(kind)
 
-    def test_instance(self):
-        v = InvalidValue()
-        assert_that(v, is_(instance_of(InvalidValue)))
+    def test_instance(self, kind=InvalidValue):
+        from zope.schema import interfaces as sch_interfaces
+        v = kind()
+        self.assertIsInstance(v, sch_interfaces.InvalidValue)
+        self.assertIsInstance(v, InvalidValue)
 
+    def test_raise_except(self, kind=InvalidValue):
+        # It can be caught by its own name
+        with self.assertRaises(kind):
+            raise kind()
+        # It can be caught by the zope.schema name
+        from zope.schema import interfaces as sch_interfaces
+        with self.assertRaises(sch_interfaces.InvalidValue):
+            raise InvalidValue()
 
     def test_repr(self):
         assert_that(repr(InvalidValue('foo')),
                     is_("InvalidValue('foo')"))
+
+    def test_alias(self):
+        from zope.schema import interfaces as sch_interfaces
+        self.assertIs(InvalidValue, sch_interfaces.InvalidValue)


### PR DESCRIPTION
This should improve BWC.

It requires an ugly hack for ``__init__``, but I couldn't find a way to make all the properties work out with a combo of ``__new__`` and metaclasses. (Specifically, it seems `except Foo:` ignores
``__instancecheck__`` in the metaclass.)