### PR TITLE
Make fromObject used by Variant and FromObject classes handle AttributeError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,13 @@
 1.9.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Make ``VariantValidationError`` and ``Variant`` have more useful
+  string representations.
+
+- Make ``fromObject`` methods more gracefully handle an AttributeError
+  raised by an underlying ``fromUnicode`` method on non-string input
+  (such as None). This is especially helpful for ``Variant`` fields
+  because they can catch the error and continue to the next field.
 
 
 1.9.0 (2018-10-02)

--- a/src/nti/schema/interfaces.py
+++ b/src/nti/schema/interfaces.py
@@ -10,6 +10,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import traceback
+
 from zope.deprecation import deprecated
 
 from zope.schema import Text
@@ -209,6 +211,31 @@ class VariantValidationError(sch_interfaces.ValidationError):
         super(VariantValidationError, self).__init__()
         self.with_field_and_value(field, value)
         self.errors = errors
+
+    def _ex_details(self):
+        lines = []
+        for e in self.errors:
+            info = traceback.format_exception_only(type(e), e)
+            # Trim trailing newline
+            info[-1] = info[-1].rstrip()
+            lines.append('\n'.join(info))
+        return lines
+
+    def _with_details(self, opening, detail_formatter):
+        lines = ['      ' + e for e in self._ex_details()]
+        lines.append('    Field: ' + detail_formatter(self.field))
+        lines.append('    Value: ' + detail_formatter(self.value))
+        lines.append(opening)
+        lines.reverse()
+        return '\n'.join(lines)
+
+    def __str__(self):
+        s = super(VariantValidationError, self).__str__()
+        return self._with_details(s, str)
+
+    def __repr__(self):
+        s = super(VariantValidationError, self).__repr__()
+        return self._with_details(s, repr)
 
 class IListOrTuple(sch_interfaces.IList):
     pass


### PR DESCRIPTION
This could occur when passing None to fromUnicode(), something we
always do as a final fallback, even if the type isn't a str/bytes.
This is more likely now as we attempt more conversions.

We catch the error instead of doing an 'if not None' check to allow
for fields that *want* to handle None values in fromUnicode.

Also provide more useful reprs for VariantValidationError:

```
VariantValidationError()
    Value: None
    Field: <nti.schema.field.Variant at 0x10b2666d8 name='' interface=None context=None fields=[<nti.schema.field.HTTPURL object at 0x10b266a58>]>
      zope.schema._bootstrapinterfaces.WrongType: (None, <class 'str'>, '')`
```
