### PR TITLE
Variant ond other fromObject fields call validate() as the last resort, not fromUnicode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,16 @@
 1.9.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix ``Variant`` and other implementations of ``IFromObject`` to stop
+  passing known non-text values to ``fromUnicode`` methods. This only
+  worked with certain fields (such as ``zope.schema.Number``) that
+  could accept non-text values, usually by implementation accident,
+  and could have surprising consequences. Instead, non-text values
+  will be passed to the ``validate`` method.
 
+- Fix ``Variant`` to stop double-validating values. The underlying
+  ``fromUnicode``, ``fromBytes`` or ``fromObject`` methods were
+  supposed to already validate.
 
 1.9.1 (2018-10-03)
 ==================


### PR DESCRIPTION
We *know* we don't have a string, so calling fromUnicode doesn't make sense. It only worked in rare cases too, and those could sometimes be surprising. Examples of working but surprising cases include zope.schema.Bool and the deprecated nti.schema.field.Number. This cleans up the ugly AttributeError workaround.

Also make Variant stop double-validating.