### PR TITLE
Add StrippedValidTextLine to strip leading/trailing ws from values.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,11 +3,11 @@
 =========
 
 
-1.12.1 (unreleased)
+1.13.0(unreleased)
 ===================
 
-- Nothing changed yet.
-
+- Add ``StrippedValidTextLine`` field to strip leading/trailing
+  whitespace from values.
 
 1.12.0 (2018-10-10)
 ===================

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import codecs
 from setuptools import setup, find_packages
 
-version = '1.12.1.dev0'
+version = '1.13.0.dev0'
 
 entry_points = {
 }

--- a/src/nti/schema/field.py
+++ b/src/nti/schema/field.py
@@ -636,6 +636,8 @@ _is_stripped = re.compile(_is_stripped).match
 class StrippedValidTextLine(DecodingValidTextLine):
     """
     A text line that strips whitespace from incoming values.
+
+    .. versionadded:: 1.13.0
     """
 
     def fromUnicode(self, value):

--- a/src/nti/schema/tests/test_field.py
+++ b/src/nti/schema/tests/test_field.py
@@ -586,7 +586,7 @@ class TestStrippedValidTextLine(unittest.TestCase):
             foo = FieldProperty(field)
 
         assert_that(field.fromUnicode(u' abc '), equal_to(u'abc'))
-        assert_that(field.fromBytes(' abc '), equal_to(u'abc'))
+        assert_that(field.fromBytes(b' abc '), equal_to(u'abc'))
         assert_that(calling(setattr).with_args(Thing(), 'foo', u' abc '), raises(InvalidValue))
 
         # Check valid case


### PR DESCRIPTION
This is potentially useful for any fields we want to ensure are stripped, which can be particularly useful, e.g. for ensuring uniqueness in a container (NTI-7615 is one issue that could have benefited).