### PR TITLE
Make SchemaConfigured up to 100% faster

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,15 @@
  Changes
 =========
 
-1.14.1 (unreleased)
+1.15.0 (unreleased)
 ===================
 
-- Nothing changed yet.
+- Improve the speed of ``SchemaConfigured`` subclasses. See `issue 54
+  <https://github.com/NextThought/nti.schema/issues/54>`_.
+
+  This involves some caching, so be sure to read the documentation for
+  ``nti.schema.schema`` if you ever mutate classes directly, or mutate
+  the results of ``schemadict``.
 
 
 1.14.0 (2020-03-27)

--- a/benchmarks/bench_schemaconfigured.py
+++ b/benchmarks/bench_schemaconfigured.py
@@ -1,0 +1,149 @@
+from __future__ import print_function, absolute_import
+import pyperf
+
+from zope.interface import Interface
+from zope.interface import classImplements
+from zope.interface import implementer
+from zope.interface.interface import InterfaceClass
+
+from nti.schema.field import Bool
+from nti.schema.schema import SchemaConfigured
+from nti.schema.fieldproperty import createFieldProperties
+
+# The number of interfaces seems to directly relate to the speed, with more
+# being much slower.
+INTERFACE_COUNT = 20
+INNERLOOPS = 100
+# A bunch of interfaces, each declaring
+# one field. No inheritance.
+shallow_ifaces = [
+    InterfaceClass(
+        'I' + ('0' * 20) + str(i),
+        (Interface,),
+        {'field_' + str(i): Bool()}
+    )
+    for i in range(INTERFACE_COUNT)
+]
+
+def make_shallow_classes():
+    classes = []
+    for iface in shallow_ifaces:
+        cls = type(
+            'Class' + iface.__name__,
+            (object,),
+            {}
+        )
+        classImplements(cls, iface)
+        classes.append(cls)
+    return classes
+
+shallow_classes = make_shallow_classes()
+
+IWideInheritance = InterfaceClass(
+    'IWideInheritance',
+    tuple(shallow_ifaces),
+    {'__doc__': "Inherits from unrelated interfaces"}
+)
+
+WideInheritance = type(
+    'WideInheritance',
+    tuple(shallow_classes),
+    {'__doc__': "Inherits from unrelated classes"}
+)
+
+class SCWideInheritance(WideInheritance, SchemaConfigured):
+    pass
+
+@implementer(*shallow_ifaces)
+class ShallowInheritance(object):
+    """
+    Implements each individual interface.
+    """
+    for iface in shallow_ifaces:
+        createFieldProperties(iface)
+
+class SCShallowInheritance(ShallowInheritance, SchemaConfigured):
+    pass
+
+
+def make_deep_ifaces():
+    children = []
+    base = Interface
+    for i, iface in enumerate(shallow_ifaces):
+        child = InterfaceClass(
+            'IDerived' + base.__name__,
+            (iface, base,),
+            {'field_' + str(i): Bool()}
+        )
+        base = child
+        children.append(child)
+    return children
+
+deep_ifaces = make_deep_ifaces()
+# An interface that inherits from 99 other interfaces, each
+# declaring a single field.
+IDeepestInheritance = deep_ifaces[-1]
+
+def make_deep_classes(extra_bases=()):
+    classes = []
+    base = extra_bases + (object,)
+    for iface in deep_ifaces:
+        cls = type(
+            'Class' + iface.__name__,
+            base,
+            {}
+        )
+        classImplements(cls, iface)
+        base = (cls,)
+        classes.append(cls)
+
+    return classes
+
+deep_classes = make_deep_classes()
+
+@implementer(IDeepestInheritance)
+class DeepestInheritance(deep_classes[-1]):
+    """
+    A single class that implements an interface that's deeply inherited.
+
+    Has field properties.
+    """
+    createFieldProperties(IDeepestInheritance)
+
+sc_deep_classes = make_deep_classes((SchemaConfigured,))
+
+@implementer(IDeepestInheritance)
+class SCDeepestInheritance(sc_deep_classes[-1], SchemaConfigured):
+    """
+    Has field properties.
+    """
+    createFieldProperties(IDeepestInheritance)
+
+def bench_create(loops, cls):
+    t0 = pyperf.perf_counter()
+    for _ in range(loops):
+        for _ in range(INNERLOOPS):
+            cls()
+    return pyperf.perf_counter() - t0
+
+
+
+runner = pyperf.Runner()
+
+for bench_cls in (
+        WideInheritance, # These have no field properties.
+        SCWideInheritance,
+        DeepestInheritance,
+        SCDeepestInheritance,
+        ShallowInheritance,
+        SCShallowInheritance
+):
+
+    runner.bench_time_func(
+        'Create ' + bench_cls.__name__,
+        bench_create,
+        bench_cls,
+        inner_loops=INNERLOOPS
+        )
+
+#bench_create(10000, SCDeepestInheritance)

--- a/src/nti/schema/tests/test_schema.py
+++ b/src/nti/schema/tests/test_schema.py
@@ -73,6 +73,20 @@ class TestSchemaConfigured(unittest.TestCase):
         a = A(field=1)
         assert_that(a, has_property('field', 1))
 
+    def test_changed(self):
+        class IA(interface.Interface):
+            field = Number()
+
+        @interface.implementer(IA)
+        class A(PermissiveSchemaConfigured):
+            pass
+
+        self.assertNotIn('__SchemaConfigured_elide_fieldproperty', A.__dict__)
+        A()
+        self.assertIn('__SchemaConfigured_elide_fieldproperty', A.__dict__)
+        A.sc_changed()
+        self.assertNotIn('__SchemaConfigured_elide_fieldproperty', A.__dict__)
+
     def test_readonly(self):
         from nti.schema.fieldproperty import createDirectFieldProperties
         class IA(interface.Interface):

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ basepython =
     python3
 commands =
     coverage run -m zope.testrunner --test-path=src []
+    coverage html
     coverage report --fail-under=100
 deps =
     {[testenv]deps}


### PR DESCRIPTION
Here are the results of testing the three commits in this PR using objects implementing 20 interfaces for a total of 20 schema fields. Benchmarks with `SC` in the name are SchemaConfigured, others are not and serve as a control. The `WideInheritance` class doesn't use any `FieldProperty` attributes, the others do.

| Benchmark                   | Master                 | Faster schemadict             | Cache schemadict              | Special-case FieldProperty      |
|-----------------------------|------------------------|-------------------------------|-------------------------------|---------------------------------|
| Create WideInheritance      | 63.8 ns                | 58.0 ns: 1.10x faster (-9%)   | 61.3 ns: 1.04x faster (-4%)   | 66.0 ns: 1.03x slower (+3%)     |
| Create SCWideInheritance    | 294 us                 | 39.8 us: 7.39x faster (-86%)  | 16.2 us: 18.11x faster (-94%) | 19.1 us: 15.42x faster (-94%)   |
| Create DeepestInheritance   | 77.8 ns                | 93.3 ns: 1.20x slower (+20%)  | 96.4 ns: 1.24x slower (+24%)  | 102 ns: 1.31x slower (+31%)     |
| Create SCDeepestInheritance | 654 us                 | 57.0 us: 11.47x faster (-91%) | 16.2 us: 40.23x faster (-98%) | 2.54 us: 257.52x faster (-100%) |
| Create ShallowInheritance   | 66.0 ns                | 57.9 ns: 1.14x faster (-12%)  | 61.1 ns: 1.08x faster (-7%)   | 63.7 ns: 1.04x faster (-4%)     |
| Create SCShallowInheritance | 304 us                 | 57.1 us: 5.33x faster (-81%)  | 33.1 us: 9.20x faster (-89%)  | 2.30 us: 132.53x faster (-99%)  |

Everything except for the very last commit ought to be totally safe (possibly modulo requiring the return from `schemadict` to be immutable). I *think* the last commit is safe as well.